### PR TITLE
Avoid calling Wire.begin when sharing an existing I2C bus

### DIFF
--- a/src/M5_EXTIO2.cpp
+++ b/src/M5_EXTIO2.cpp
@@ -2,13 +2,15 @@
 
 /*! @brief Initialize the EXTIO2.
     @return True if the init was successful, otherwise false.. */
-bool M5_EXTIO2::begin(TwoWire *wire, uint8_t sda, uint8_t scl, uint8_t addr) {
+bool M5_EXTIO2::begin(TwoWire *wire, uint8_t sda, uint8_t scl, uint8_t addr, bool initWire) {
     _wire = wire;
     _addr = addr;
     _sda  = sda;
     _scl  = scl;
-    _wire->begin((int)_sda, (int)_scl);
-    delay(10);
+    if (initWire) {
+        _wire->begin((int)_sda, (int)_scl);
+        delay(10);
+    }
     _wire->beginTransmission(_addr);
     uint8_t error = _wire->endTransmission();
     if (error == 0) {

--- a/src/M5_EXTIO2.h
+++ b/src/M5_EXTIO2.h
@@ -51,7 +51,7 @@ class M5_EXTIO2 {
 
    public:
     bool begin(TwoWire *wire = &Wire, uint8_t sda = SDA, uint8_t scl = SCL,
-               uint8_t addr = EXTIO2_DEFAULT_ADDR);
+               uint8_t addr = EXTIO2_DEFAULT_ADDR, bool initWire = true);
     bool setAllPinMode(extio_io_mode_t mode);
     bool setPinMode(uint8_t pin, extio_io_mode_t mode);
     bool setDeviceAddr(uint8_t addr);


### PR DESCRIPTION
## Summary
This change updates the EXTIO2 initialization flow so that Wire.begin is not called when the I2C bus is already managed by another module.

## Background
In projects where multiple modules share the same I2C bus, calling Wire.begin from each module can cause redundant re-initialization and unexpected side effects.  
The goal is to let users reuse a pre-configured Wire instance safely.

## What Changed
- Kept wire initialization optional in M5_EXTIO2 begin flow.
- When using a shared bus, users can initialize Wire once at the application level and skip Wire.begin inside this module.
- Preserved existing behavior for standalone usage where this module should initialize the bus itself.

## Why
- Prevents unnecessary I2C re-initialization.
- Improves compatibility with multi-module systems that share the same Wire instance.
- Makes bus ownership explicit and easier to control.

## Usage
- Standalone module usage: initialize Wire from this module as before.

```cpp
M5_EXTIO2 extio;
extio.begin(&Wire, 21, 22, 0x45);
```

- Shared bus usage: initialize Wire in the main application, then call this module without re-running Wire.begin.

```cpp
M5_EXTIO2 extio;
Wire.begin(21, 22);
extio.begin(&Wire, 21, 22, 0x45, false);
```

## Impact
- Backward compatible for existing setups.
- Safer behavior in shared I2C environments.